### PR TITLE
ansible: enable unnattended upgrades

### DIFF
--- a/images/capi/ansible/roles/sysprep/tasks/debian.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/debian.yml
@@ -17,13 +17,18 @@
     last_log_mode: "0664"
     machine_id_mode: "0644"
 
-- name: Pin all installed packages with apt-mark
-  ansible.builtin.shell: |
-    set -o pipefail
-    dpkg-query -f '${binary:Package}\n' -W | xargs apt-mark hold
-
-  args:
-    executable: /bin/bash
+# This is required to ensure any apt upgrade will not break kubernetes
+- name: Tell Debian hosts not to change the kuberetes versions with apt upgrade
+  dpkg_selections:
+    name: "{{ item }}"
+    selection: hold
+  when: ansible_pkg_mgr == 'apt'
+  changed_when: false
+  with_items:
+    - kubelet
+    - kubeadm
+    - kubectl
+    - kubernetes-cni
 
 - name: Remove extra repos
   ansible.builtin.file:
@@ -75,24 +80,8 @@
     - { path: /var/lib/apt/lists, state: absent, mode: "0755" }
     - { path: /var/lib/apt/lists, state: directory, mode: "0755" }
 
-- name: Disable apt-daily services
-  ansible.builtin.systemd:
-    name: "{{ item }}"
-    state: stopped
-    enabled: false
-  loop:
-    - apt-daily.timer
-    - apt-daily-upgrade.timer
-
 - name: Get installed packages
   ansible.builtin.package_facts:
-
-- name: Disable unattended upgrades if installed
-  ansible.builtin.systemd:
-    name: unattended-upgrades
-    state: stopped
-    enabled: false
-  when: "'unattended-upgrades' in ansible_facts.packages"
 
 - name: Reset network interface IDs
   ansible.builtin.file:


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

This enables unattended upgrades. It also holds some packages connected to the kubernetes version, so they are not accidentally upgraded.


## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
