### PR TITLE
update broken iso url for ubuntu 24.04

### DIFF
--- a/images/capi/packer/qemu/qemu-ubuntu-2404-efi.json
+++ b/images/capi/packer/qemu/qemu-ubuntu-2404-efi.json
@@ -7,7 +7,7 @@
   "guest_os_type": "ubuntu-64",
   "iso_checksum": "e240e4b801f7bb68c20d1356b60968ad0c33a41d00d828e74ceb3364a0317be9",
   "iso_checksum_type": "sha256",
-  "iso_url": "https://releases.ubuntu.com/releases/24.04/ubuntu-24.04.1-live-server-amd64.iso",
+  "iso_url": "https://releases.ubuntu.com/releases/24.04/ubuntu-24.04.2-live-server-amd64.iso",
   "os_display_name": "Ubuntu 24.04",
   "shutdown_command": "shutdown -P now",
   "unmount_iso": "true"

--- a/images/capi/packer/qemu/qemu-ubuntu-2404.json
+++ b/images/capi/packer/qemu/qemu-ubuntu-2404.json
@@ -6,7 +6,7 @@
   "guest_os_type": "ubuntu-64",
   "iso_checksum": "e240e4b801f7bb68c20d1356b60968ad0c33a41d00d828e74ceb3364a0317be9",
   "iso_checksum_type": "sha256",
-  "iso_url": "https://releases.ubuntu.com/releases/24.04/ubuntu-24.04.1-live-server-amd64.iso",
+  "iso_url": "https://releases.ubuntu.com/releases/24.04/ubuntu-24.04.2-live-server-amd64.iso",
   "os_display_name": "Ubuntu 24.04",
   "shutdown_command": "shutdown -P now",
   "unmount_iso": "true"


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->



## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

The ubuntu iso url has broken in the packer configuration for 24.04

## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
