### PR TITLE
Update ubuntu patch version

### DIFF
--- a/images/capi/packer/qemu/qemu-ubuntu-2404-efi.json
+++ b/images/capi/packer/qemu/qemu-ubuntu-2404-efi.json
@@ -5,9 +5,9 @@
   "distro_name": "ubuntu",
   "firmware": "OVMF.fd",
   "guest_os_type": "ubuntu-64",
-  "iso_checksum": "d6dab0c3a657988501b4bd76f1297c053df710e06e0c3aece60dead24f270b4d",
+  "iso_checksum": "c3514bf0056180d09376462a7a1b4f213c1d6e8ea67fae5c25099c6fd3d8274b",
   "iso_checksum_type": "sha256",
-  "iso_url": "https://releases.ubuntu.com/releases/24.04/ubuntu-24.04.2-live-server-amd64.iso",
+  "iso_url": "https://releases.ubuntu.com/releases/24.04/ubuntu-24.04.3-live-server-amd64.iso",
   "os_display_name": "Ubuntu 24.04",
   "shutdown_command": "shutdown -P now",
   "unmount_iso": "true"

--- a/images/capi/packer/qemu/qemu-ubuntu-2404.json
+++ b/images/capi/packer/qemu/qemu-ubuntu-2404.json
@@ -4,9 +4,9 @@
   "distribution_version": "2404",
   "distro_name": "ubuntu",
   "guest_os_type": "ubuntu-64",
-  "iso_checksum": "d6dab0c3a657988501b4bd76f1297c053df710e06e0c3aece60dead24f270b4d",
+  "iso_checksum": "c3514bf0056180d09376462a7a1b4f213c1d6e8ea67fae5c25099c6fd3d8274b",
   "iso_checksum_type": "sha256",
-  "iso_url": "https://releases.ubuntu.com/releases/24.04/ubuntu-24.04.2-live-server-amd64.iso",
+  "iso_url": "https://releases.ubuntu.com/releases/24.04/ubuntu-24.04.3-live-server-amd64.iso",
   "os_display_name": "Ubuntu 24.04",
   "shutdown_command": "shutdown -P now",
   "unmount_iso": "true"


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

I tried building an image and got this error:

```
==> qemu: Retrieving ISO
==> qemu: Trying https://releases.ubuntu.com/releases/24.04/ubuntu-24.04.2-live-server-amd64.iso
==> qemu: Trying https://releases.ubuntu.com/releases/24.04/ubuntu-24.04.2-live-server-amd64.iso?checksum=sha256%3Ad6dab0c3a
657988501b4bd76f1297c053df710e06e0c3aece60dead24f270b4d       
==> qemu: Download failed bad response code: 404
==> qemu: error downloading ISO: [bad response code: 404]
Build 'qemu' errored after 882 milliseconds 322 microseconds: error downloading ISO: [bad response code: 404]

==> Wait completed after 884 milliseconds 550 microseconds

==> Some builds didn't complete successfully and had errors:
--> qemu: error downloading ISO: [bad response code: 404]

==> Builds finished but no artifacts were created.
make: *** [Makefile:560: build-qemu-ubuntu-2404] Error 1
[image.bash]: openstack build failure!
[image.bash]: openstack build failure!
```

Ubuntu has released [24.04.3](https://releases.ubuntu.com/releases/24.04/) and it seems like they removed the possibility to download 24.04.2.

This updates two files so that we can build images again. This has not been updated upstream, so I assume I should make a PR there as well. Or should I make a PR there instead of this one? (for the upstream PR I think there are some more files that should also get this update.


## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
